### PR TITLE
Fixes Issue #3. Ignores being hosted on IIS7

### DIFF
--- a/src/OpenRasta.Hosting.AspNet/OpenRastaModule.cs
+++ b/src/OpenRasta.Hosting.AspNet/OpenRastaModule.cs
@@ -23,7 +23,7 @@ namespace OpenRasta.Hosting.AspNet
     {
         internal const string COMM_CONTEXT_KEY = "__OR_COMM_CONTEXT";
         internal const string ORIGINAL_PATH_KEY = "__ORIGINAL_PATH";
-        internal const string SERVER_SOFTWARE_KEY = "SERVER_SOFTWARE_KEY";
+        internal const string SERVER_SOFTWARE_KEY = "SERVER_SOFTWARE";
 
         internal static HostManager HostManager;
         static readonly object _syncRoot = new object();


### PR DESCRIPTION
Fixes issue with ignoring being hosted on IIS7, https://github.com/openrasta/openrasta-hosting-aspnet/issues/3
Changed the SERVER_SOFTWARE_KEY to 'SERVER_SOFTWARE' to match the one provided in Request.ServerVariables
