### PR TITLE
Default Documents in '/' Root still not fixed?

### DIFF
--- a/src/OpenRasta.Hosting.AspNet/OpenRastaModule.cs
+++ b/src/OpenRasta.Hosting.AspNet/OpenRastaModule.cs
@@ -135,27 +135,37 @@ namespace OpenRasta.Hosting.AspNet
         static void HandleHttpApplicationPostResolveRequestCacheEvent(object sender, EventArgs e)
         {
             VerifyIisDetected(HttpContext.Current);
-            if (!HostingEnvironment.VirtualPathProvider.FileExists(HttpContext.Current.Request.Path)
-                && (HttpContext.Current.Request.Path == "/" || !HostingEnvironment.VirtualPathProvider.DirectoryExists(HttpContext.Current.Request.Path))
-                && !HandlerAlreadyMapped(HttpContext.Current.Request.HttpMethod, HttpContext.Current.Request.Url))
-            {
-                Log.StartPreExecution();
-                var context = CommunicationContext;
-                var stage = context.PipelineData.PipelineStage;
-                if (stage == null)
-                    context.PipelineData.PipelineStage = stage = new PipelineStage(HostManager.Resolver.Resolve<IPipeline>());
-                stage.SuspendAfter<KnownStages.IUriMatching>();
-                Host.RaiseIncomingRequestReceived(context);
 
-                if (context.PipelineData.ResourceKey != null || context.OperationResult != null)
-                {
-                    HttpContext.Current.Items[ORIGINAL_PATH_KEY] = HttpContext.Current.Request.Path;
-                    HttpContext.Current.RewritePath(VirtualPathUtility.ToAppRelative("~/ignoreme.rastahook"), false);
-                    Log.PathRewrote();
-                    return;
-                }
-                Log.IgnoredRequest();
+            if (HostingEnvironment.VirtualPathProvider.FileExists(HttpContext.Current.Request.Path) ) 
+                return; //don't process file files on disk
+
+            if( HttpContext.Current.Request.Path == "/" )
+                return; //don't handle root '/' requests in IIS whatsoever.
+
+            if( HttpContext.Current.Request.Path != "/" && HostingEnvironment.VirtualPathProvider.DirectoryExists(HttpContext.Current.Request.Path)) 
+                return; //don't handle actual directories that exist
+
+            if( HandlerAlreadyMapped(HttpContext.Current.Request.HttpMethod, HttpContext.Current.Request.Url)) 
+                return; //don't process requests that are handled by IIS handlers
+
+            //else continue processing with OpenRasta
+
+            Log.StartPreExecution();
+            var context = CommunicationContext;
+            var stage = context.PipelineData.PipelineStage;
+            if (stage == null)
+                context.PipelineData.PipelineStage = stage = new PipelineStage(HostManager.Resolver.Resolve<IPipeline>());
+            stage.SuspendAfter<KnownStages.IUriMatching>();
+            Host.RaiseIncomingRequestReceived(context);
+
+            if (context.PipelineData.ResourceKey != null || context.OperationResult != null)
+            {
+                HttpContext.Current.Items[ORIGINAL_PATH_KEY] = HttpContext.Current.Request.Path;
+                HttpContext.Current.RewritePath(VirtualPathUtility.ToAppRelative("~/ignoreme.rastahook"), false);
+                Log.PathRewrote();
+                return;
             }
+            Log.IgnoredRequest();
         }
     }
 }


### PR DESCRIPTION
According to the current source file, I don't think this issue has been fixed yet even though it's been closed: https://github.com/openrasta/openrasta-stable/issues/19

The problem is with the original 'HttpContext.Current.Request.Path == "/"' statement. The original IF statement is true even when the path is /. This takes away processing from IIS's default document loader; OpenRasta will continue processing if the path is "/".

This is NOT the desired behavior when root default documents are set.

My proposed change simplifies the original hard-to-read IF statement with a more decent check of individual IF short-circuit cancel processing statements. AND correctly exists if the request path is "/" (root).
